### PR TITLE
INFRA-598 - Allow prometheus scraping of /metrics when using auth

### DIFF
--- a/flower/views/monitor.py
+++ b/flower/views/monitor.py
@@ -7,7 +7,6 @@ from ..views import BaseHandler
 
 
 class Metrics(BaseHandler):
-    @web.authenticated
     @gen.coroutine
     def get(self):
         self.write(prometheus_client.generate_latest())


### PR DESCRIPTION
What does this do ?
* We only use Authentication to protect the Flower Web UI